### PR TITLE
讓從統一金流回傳的資訊會顯示在 thank you page 及訂單的 Note 給顧客也看得到

### DIFF
--- a/class-payuni.php
+++ b/class-payuni.php
@@ -79,7 +79,7 @@ function payuni_gateway_init()
 
             // Actions
             add_action('woocommerce_update_options_payment_gateways_' . $this->id, array(&$this, 'process_admin_options'));
-            add_action('woocommerce_thankyou_' . $this->id, array($this, 'thankyou_page'));
+            add_action('woocommerce_thankyou', array($this, 'thankyou_page'));
             add_action('woocommerce_receipt_' . $this->id, array($this, 'receipt_page'));
             add_action('woocommerce_api_wc_' . $this->id, array($this, 'receive_response')); //api_"class名稱(小寫)"
         }
@@ -313,7 +313,7 @@ function payuni_gateway_init()
                         exit;
                     }
                     $message = $this->SetNotice($encryptInfo);
-                    $order->add_order_note($message);
+                    $order->add_order_note($message, 1);
                     switch ($encryptInfo['TradeStatus']) {
                         case '0':
                             $order->update_status('on-hold', __('Awaiting cheque payment', 'woocommerce'));


### PR DESCRIPTION
實際安裝後，有消費者反應，
選擇 ATM 後，在感謝頁面沒有看到匯款帳號
而訂單備註中雖然有匯款帳號，
單只有管理員能看到，消費者並不會看到，
沒有習慣收Email的消費者，會不知道匯款帳號，
因此修改為在感謝頁面及訂單備註也會出現取號結果
